### PR TITLE
Add websites to package.xml files

### DIFF
--- a/scaled_controllers/package.xml
+++ b/scaled_controllers/package.xml
@@ -9,7 +9,7 @@
 
   <license>Apache-2.0</license>
 
-  <!-- <url type="website">http://wiki.ros.org/scaled_controllers</url> -->
+  <url type="website">http://wiki.ros.org/scaled_controllers</url>
 
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>scaled_joint_trajectory_controller</exec_depend>

--- a/scaled_joint_trajectory_controller/package.xml
+++ b/scaled_joint_trajectory_controller/package.xml
@@ -17,10 +17,7 @@
   <license file="include/scaled_joint_trajectory_controller/scaled_joint_command_interface.h">BSD-3-Clause</license>
 
 
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/scaled_joint_trajectory_controller</url> -->
+  <url type="website">http://wiki.ros.org/scaled_joint_trajectory_controller</url>
 
 
   <!-- Author tags are optional, multiple are allowed, one per tag -->

--- a/speed_scaling_state_controller/package.xml
+++ b/speed_scaling_state_controller/package.xml
@@ -16,10 +16,7 @@
   <license>Apache-2.0</license>
 
 
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/speed_scaling_state_controller</url> -->
+  <url type="website">http://wiki.ros.org/speed_scaling_state_controller</url>
 
 
   <!-- Author tags are optional, multiple are allowed, one per tag -->


### PR DESCRIPTION
We've created ROS wiki pages for this repo's packages. Let's use them in the `package-xml` files.